### PR TITLE
Update cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ authlib==0.14.3
 backports.zoneinfo==0.2.1
 blinker==1.4
 certifi==2019.11.28
-cffi==1.14.0
+cffi==1.15.0
 chardet==3.0.4
 click==7.1.2
 cryptography==3.3.2


### PR DESCRIPTION
Not needed in production, but is needed to developer on M1 Macs.
