### PR TITLE
Remove backports.zoneinfo

### DIFF
--- a/fructify/googleevents.py
+++ b/fructify/googleevents.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 
 def parse_event_time(time_playload, calendar_tz):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #    pip-compile --no-annotate --no-emit-index-url
 #
 authlib==0.14.3
-backports-zoneinfo==0.2.1
 blinker==1.4
 certifi==2019.11.28
 cffi==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     packages=find_packages(exclude=["tests.*"]),
     install_requires=[
         "authlib~=0.14",
-        "backports.zoneinfo~=0.2",
         "blinker~=1.4",
         "flask~=1.1",
         "honeycomb-beeline~=2.11",


### PR DESCRIPTION
Vercel is using Pythoin 3.9 now, and zoneinfo is part of the standard
library.
